### PR TITLE
Split installing man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,5 +31,7 @@ endif
 install: all
 	mkdir -p $(DESTDIR)$(PREFIX)/bin
 	cp atinout $(DESTDIR)$(PREFIX)/bin
+
+install-man: atinout.1
 	mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1
 	cp atinout.1 $(DESTDIR)$(PREFIX)/share/man/man1/atinout.1


### PR DESCRIPTION
Man pages do not build anyways in the `all` target in this fork, and their build even fails due to encoding issues on my machine.